### PR TITLE
Patch to be same as lukestephenson/capybara-select2

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -8,12 +8,12 @@ module Capybara
       raise "Must pass a hash containing 'from' or 'xpath' or 'css'" unless options.is_a?(Hash) and [:from, :xpath, :css].any? { |k| options.has_key? k }
 
       if options.has_key? :xpath
-        select2_container = find(:xpath, options[:xpath])
+        select2_container = first(:xpath, options[:xpath])
       elsif options.has_key? :css
-        select2_container = find(:css, options[:css])
+        select2_container = first(:css, options[:css])
       else
         select_name = options[:from]
-        select2_container = find("label", text: select_name).find(:xpath, '..').find(".select2-container")
+        select2_container = first("label", text: select_name).find(:xpath, '..').find(".select2-container")
       end
 
       # Open select2 field


### PR DESCRIPTION
https://github.com/lukestephenson/capybara-select2
を以前使っていたが、こちらが消えてしまったようなので同じ diff を当て直す

## diff

```diff
11c11
<         select2_container = find(:xpath, options[:xpath])
---
>         select2_container = first(:xpath, options[:xpath])
13c13
<         select2_container = find(:css, options[:css])
---
>         select2_container = first(:css, options[:css])
16c16
<         select2_container = find("label", text: select_name).find(:xpath, '..').find(".select2-container")
---
>         select2_container = first("label", text: select_name).find(:xpath, '..').find(".select2-container")
```

他の構成ファイルは diff なし